### PR TITLE
Fix  ld: multiple definition of `random_data_flag'

### DIFF
--- a/linux/src/fping.h
+++ b/linux/src/fping.h
@@ -11,7 +11,7 @@
 void crash_and_burn( char *message );
 void errno_crash_and_burn( char *message );
 int in_cksum( unsigned short *p, int n );
-int random_data_flag;
+extern int random_data_flag;
 
 /* socket.c */
 int  open_ping_socket_ipv4();


### PR DESCRIPTION
Upstream solution: https://github.com/schweikert/fping/issues/166#issuecomment-581100782